### PR TITLE
Update dependencies and upgrade Node.js runtime

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 14
+      nodejs: 22
     commands:
       - npm install
   build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,38 @@
 {
   "name": "blog",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "marked": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
-      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q=="
+  "packages": {
+    "": {
+      "name": "blog",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^18.0.5",
+        "mustache": "^4.2.0"
+      }
     },
-    "mustache": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.1.0.tgz",
-      "integrity": "sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ=="
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/nmcginn/blog#readme",
   "dependencies": {
-    "marked": "^2.0.0",
-    "mustache": "^4.1.0"
+    "marked": "^18.0.5",
+    "mustache": "^4.2.0"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -15,7 +15,7 @@ const titles = [];
 posts.forEach(file => {
     const content = fs.readFileSync(`posts/${file}`).toString('utf-8');
     titles.push(content.substring(2, content.indexOf('\n')));
-    const html = marked(content);
+    const html = marked.parse(content);
     const fullContent = mustache.render(template, { content: html });
     fs.writeFileSync(`site/${file.replace('.md', '.html')}`, fullContent, { encoding: 'utf-8' });
     console.log(`${file.replace('.md', '.html')} rendered`);
@@ -27,6 +27,6 @@ for (let i = 0; i < posts.length; i++) {
 }
 
 const index = fs.readFileSync('index.md').toString('utf-8');
-const indexFullContent = mustache.render(template, { content: marked(index + siteDirectory) });
+const indexFullContent = mustache.render(template, { content: marked.parse(index + siteDirectory) });
 fs.writeFileSync('site/index.html', indexFullContent, { encoding: 'utf-8' });
 console.log('index.html rendered');


### PR DESCRIPTION
## Summary
This PR updates project dependencies to their latest versions and upgrades the Node.js runtime to support the new API changes introduced in marked v18.

## Key Changes
- **Dependency Updates:**
  - `marked`: ^2.0.0 → ^18.0.5
  - `mustache`: ^4.1.0 → ^4.2.0
  - Node.js runtime: 14 → 22

- **API Migration:**
  - Updated `marked()` function calls to `marked.parse()` to comply with marked v18's new API
  - Changes applied in two locations: post rendering and index rendering in `scripts/build.js`

## Implementation Details
The marked library v18 introduced a breaking change where the default export is no longer a function but an object with a `parse()` method. All invocations of `marked(content)` have been updated to `marked.parse(content)` to maintain compatibility with the new version.

https://claude.ai/code/session_01LXo6Nmj2rWWyP2sxZKPefd