### PR TITLE
Add landing page and move blog to /blog subdirectory

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,6 +7,7 @@ const mustache = require('mustache');
 if (fs.existsSync('site/'))
     fs.rmSync('site/', { recursive: true });
 fs.mkdirSync('site/');
+fs.mkdirSync('site/blog/');
 
 const template = fs.readFileSync('scripts/template.mustache').toString('utf-8');
 
@@ -17,8 +18,8 @@ posts.forEach(file => {
     titles.push(content.substring(2, content.indexOf('\n')));
     const html = marked.parse(content);
     const fullContent = mustache.render(template, { content: html });
-    fs.writeFileSync(`site/${file.replace('.md', '.html')}`, fullContent, { encoding: 'utf-8' });
-    console.log(`${file.replace('.md', '.html')} rendered`);
+    fs.writeFileSync(`site/blog/${file.replace('.md', '.html')}`, fullContent, { encoding: 'utf-8' });
+    console.log(`blog/${file.replace('.md', '.html')} rendered`);
 });
 
 let siteDirectory = '\n\n';
@@ -28,5 +29,9 @@ for (let i = 0; i < posts.length; i++) {
 
 const index = fs.readFileSync('index.md').toString('utf-8');
 const indexFullContent = mustache.render(template, { content: marked.parse(index + siteDirectory) });
-fs.writeFileSync('site/index.html', indexFullContent, { encoding: 'utf-8' });
+fs.writeFileSync('site/blog/index.html', indexFullContent, { encoding: 'utf-8' });
+console.log('blog/index.html rendered');
+
+const landing = fs.readFileSync('scripts/landing.html').toString('utf-8');
+fs.writeFileSync('site/index.html', landing, { encoding: 'utf-8' });
 console.log('index.html rendered');

--- a/scripts/landing.html
+++ b/scripts/landing.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Nathan McGinn</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+            max-width: 640px;
+            margin: 3em auto;
+            padding: 0 1.5em;
+            line-height: 1.6;
+        }
+        h1 { margin-bottom: 0.2em; }
+        .tagline { color: #666; margin-top: 0; margin-bottom: 2.5em; }
+        h2 { border-bottom: 1px solid #ddd; padding-bottom: 0.3em; }
+        .projects { list-style: none; padding: 0; }
+        .projects li { margin: 1.25em 0; }
+        .projects a { font-weight: bold; font-size: 1.05em; }
+        .desc { display: block; color: #555; font-size: 0.9em; margin-top: 0.15em; }
+        .soon { font-weight: bold; font-size: 1.05em; opacity: 0.45; }
+        @media screen and (prefers-color-scheme: dark) {
+            :root { background-color: #232323; color: #d0d0d0; }
+            a:link, a:hover { color: #6495ed; }
+            a:active, a:visited { color: #a37af9; }
+            h2 { border-bottom-color: #444; }
+            .tagline, .desc { color: #999; }
+        }
+    </style>
+</head>
+<body>
+<h1>Nathan McGinn</h1>
+<p class="tagline">Software developer &amp; researcher.</p>
+<h2>Projects</h2>
+<ul class="projects">
+    <li>
+        <a href="https://github.com/nmcginn/spookyweather">Spooky Weather</a>
+        <span class="desc">Weather forecasts, spookified.</span>
+    </li>
+    <li>
+        <a href="https://github.com/nmcginn/kanji-study">Kanji Study</a>
+        <span class="desc">A flashcard tool for studying Japanese kanji.</span>
+    </li>
+    <li>
+        <span class="soon">PhD Dissertation</span>
+        <span class="desc">Coming soon.</span>
+    </li>
+    <li>
+        <a href="/blog">Blog</a>
+        <span class="desc">Writing on software, systems, and adjacent topics.</span>
+    </li>
+</ul>
+</body>
+</html>

--- a/scripts/template.mustache
+++ b/scripts/template.mustache
@@ -8,6 +8,12 @@
         body {
             font-family: Arial, Helvetica, sans-serif;
         }
+        nav {
+            font-size: 0.9em;
+            margin-bottom: 2em;
+            color: #888;
+        }
+        nav a { margin-right: 1em; }
         img {
             max-width: 95%;
         }
@@ -32,10 +38,14 @@
             img:hover {
                 opacity: 1;
             }
+            nav {
+                color: #666;
+            }
         }
     </style>
 </head>
 <body>
+<nav><a href="/">home</a> <a href="/blog">blog</a></nav>
 {{{ content }}}
 </body>
 </html>


### PR DESCRIPTION
- New scripts/landing.html: minimal no-JS landing page with links to
  Spooky Weather, Kanji Study, PhD dissertation (coming soon), and blog
- Build now outputs posts and blog index to site/blog/ instead of site/
- template.mustache gains a subtle home/blog nav on all blog pages

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dvc7Ka3R1gF6EmDPTW5Afr